### PR TITLE
Convert string port to int in InetSocketTransportAddress() ctor call.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ plugins {
     id "de.undercouch.download" version "3.2.0"
 }
 
-version "2.5.0.BUILD-SNAPSHOT"
+version "2.5.1.BUILD-SNAPSHOT"
 group "org.grails.plugins"
 
 apply plugin: 'eclipse'

--- a/src/main/groovy/grails/plugins/elasticsearch/ClientNodeFactoryBean.groovy
+++ b/src/main/groovy/grails/plugins/elasticsearch/ClientNodeFactoryBean.groovy
@@ -105,12 +105,19 @@ class ClientNodeFactoryBean implements FactoryBean {
                 if (!elasticSearchContextHolder.config.client.hosts) {
                     transportClient.addTransportAddress(new InetSocketTransportAddress(new InetSocketAddress('localhost', 9300)))
                 } else {
+                    def debugEnabled = LOG.isDebugEnabled()
                     elasticSearchContextHolder.config.client.hosts.each {
                         try {
+                            if (debugEnabled) {
+                                LOG.debug("Trying this host:  ${it.host}")
+                            }
                             for (InetAddress address : InetAddress.getAllByName(it.host)) {
+                                if (debugEnabled) {
+                                    LOG.debug("Gonna add host: ${address.getHostAddress()}:${it.port}")
+                                }
                                 if ((ip6Enabled && address instanceof Inet6Address) || (ip4Enabled && address instanceof Inet4Address)) {
-                                    LOG.info("Adding host: ${address}:${it.port}")
-                                    transportClient.addTransportAddress(new InetSocketTransportAddress(address, it.port));
+                                    LOG.info("Adding InetAddress: ${address}:${it.port}")
+                                    transportClient.addTransportAddress(new InetSocketTransportAddress(address, Integer.parseInt(it.port)));
                                 }
                             }
                         } catch (UnknownHostException e) {


### PR DESCRIPTION
* Added port conversion from string to in in InetSocketTransportAddressctor. Was not able to connect to Elasticserach v 6.4.2 due to this error: Could not find matching constructor for: org.elasticsearch.common.transport.InetSocketTransportAddress(java.net.Inet4Address, java.lang.String)

* Added some debug logging.