### PR TITLE
Fixes field with same name under same domain conflict

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,20 @@
+# Gradle build and deploy to github maven package.
+
+# Gradle build.
+
+name: Java Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Build with Gradle
+        run: ./gradlew build test 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,26 @@
+# publish-release.yml
+# https://medium.com/@shanemyrick/publishing-to-github-packages-with-gradle-and-github-actions-4ad842634c4e
+
+name: Publish release
+
+on: [push]
+
+jobs:
+  publish-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout latest code
+        uses: actions/checkout@v1
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Publish artifact
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+        run: |
+          ./gradlew publish

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ plugins {
     id "de.undercouch.download" version "3.2.0"
 }
 
-version "3.0.0.BUILD-SNAPSHOT"
+version "3.0.1.BUILD-SNAPSHOT"
 group "org.grails.plugins"
 
 apply plugin: 'eclipse'

--- a/build.gradle
+++ b/build.gradle
@@ -155,6 +155,27 @@ bootRun {
 // enable if you wish to package this plugin as a standalone application
 bootJar.enabled = false
 
+
+publishing {
+
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/muyantech/elasticsearch-grails-plugin")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
+
+  publications {
+        gpr(MavenPublication) {
+            from(components.java)
+        }
+    }
+}
+
 apply from: "gradle/documentation.gradle"
 
 apply from: "gradle/publish.gradle"

--- a/src/main/groovy/grails/plugins/elasticsearch/mapping/SearchableClassMapping.groovy
+++ b/src/main/groovy/grails/plugins/elasticsearch/mapping/SearchableClassMapping.groovy
@@ -84,7 +84,7 @@ class SearchableClassMapping implements ElasticSearchConfigAware {
     }
 
     String calculateIndexName() {
-        String name = (esConfig?.get('index') as ConfigObject)?.name ?: domainClass.packageName
+        String name = (esConfig?.get('index') as ConfigObject)?.name ?: domainClass.getClass().getName()
 
         if (name == null || name.length() == 0) {
             name = domainClass.defaultPropertyName


### PR DESCRIPTION
Use class name instead of domain name for default index name when index to fix #47

Fixes https://github.com/puneetbehl/elasticsearch-grails-plugin/issues/47

Please see the issue for detail.