### PR TITLE
Implement support for converters as spring beans.

### DIFF
--- a/src/docs/mapping/propertiesMapping.adoc
+++ b/src/docs/mapping/propertiesMapping.adoc
@@ -25,8 +25,9 @@ static searchable = {
 | To use only on domain (or collection of domains), make the property a searchable component.
 
 | converter 
-| A `Class` 
-| A `Class` to use as a converter during the marshalling/un-marshalling process for that peculiar property. That class must extends the `PropertyEditorSupport` java class.
+| A `Class` or the name of a bean (`String`)
+| A `Class` to use as a converter during the marshalling/un-marshalling process for that peculiar property. Supplying a spring bean name allows using a fully wired and configured converter defined in `resources.groovy`.
+ That class or bean must extend the `PropertyEditorSupport` java class.
 
 | excludeFromAll 
 | `true`, `false` 

--- a/src/main/groovy/grails/plugins/elasticsearch/conversion/JSONDomainFactory.groovy
+++ b/src/main/groovy/grails/plugins/elasticsearch/conversion/JSONDomainFactory.groovy
@@ -88,6 +88,10 @@ class JSONDomainFactory {
                             marshaller = new PropertyEditorMarshaller(propertyEditorClass: converter)
                         }
                     }
+                    if (converter instanceof String) {
+                        PropertyEditor propertyEditor = grailsApplication.mainContext.getBean(converter as String) as PropertyEditor
+                        marshaller = new PropertyEditorBeanMarshaller(propertyEditor: propertyEditor)
+                    }
                 } else if (propertyMapping?.isDynamic()) {
                     marshaller = new DynamicValueMarshaller()
                 } else if (propertyMapping?.reference) {
@@ -144,7 +148,7 @@ class JSONDomainFactory {
         DomainEntity domainClass = getInstanceDomainClass(instance)
         XContentBuilder json = jsonBuilder().startObject()
         // TODO : add maxDepth in custom mapping (only for "searchable components")
-        SearchableClassMapping scm = elasticSearchContextHolder.getMappingContext(domainClass)
+        SearchableClassMapping scm = elasticSearchContextHolder.getMappingContext((DomainEntity) domainClass)
 
         DefaultMarshallingContext marshallingContext = new DefaultMarshallingContext(maxDepth: 5, parentFactory: this)
         marshallingContext.push(instance)

--- a/src/main/groovy/grails/plugins/elasticsearch/conversion/marshall/DeepDomainClassMarshaller.groovy
+++ b/src/main/groovy/grails/plugins/elasticsearch/conversion/marshall/DeepDomainClassMarshaller.groovy
@@ -27,7 +27,8 @@ class DeepDomainClassMarshaller extends DefaultMarshaller {
                 if (propertyValue.class."$searchablePropertyName") {
                     // todo fixme - will throw exception when no searchable field.
                     marshallingContext.lastParentPropertyName = prop.name
-                    if (propertyMapping?.isGeoPoint()) {
+                    // Converters build a string value out of a class so we can just add it
+                    if (propertyMapping?.isGeoPoint() || propertyMapping.converter != null) {
                         marshallResult += [(prop.name): (marshallingContext.delegateMarshalling(propertyValue, propertyMapping.maxDepth))]
                     } else {
                         marshallResult += [(prop.name): ([id: propertyValue.ident(), 'class': propertyClassName] + marshallingContext.delegateMarshalling(propertyValue, propertyMapping.maxDepth))]

--- a/src/main/groovy/grails/plugins/elasticsearch/conversion/marshall/PropertyEditorBeanMarshaller.groovy
+++ b/src/main/groovy/grails/plugins/elasticsearch/conversion/marshall/PropertyEditorBeanMarshaller.groovy
@@ -1,0 +1,13 @@
+package grails.plugins.elasticsearch.conversion.marshall
+
+class PropertyEditorBeanMarshaller extends DefaultMarshaller {
+
+    def propertyEditor
+
+    @Override
+    protected doMarshall(Object object) {
+        assert propertyEditor != null
+        propertyEditor.setValue(object)
+        propertyEditor.getAsText()
+    }
+}


### PR DESCRIPTION
We needed a more powerful property conversion option in one of our project where we indexed Pdf files. This pull request adds the option to add a converter to a searchable property that is used to extract a string out of some opaque object. This converter is a spring bean and extends java.beans.PropertyEditorSupport.

Usage:
1) Implement a converter bean :
```
class PdfAttachmentConverter extends PropertyEditorSupport {
    AttachmentService service  // injected grails service we need

    @Override
    String getAsText() {
        Attachment attachment = value as Attachment
        return service.extractString(attachment)
    }

    @Override
    void setValue(Object value) {
        super.setValue(value)
    }
}
```

2) Register converter as a bean in spring config (resources.groovy):
```
    attachmentConverter(PdfAttachmentConverter) {
        attachmentService = ref('attachmentService')
    }
```
3) Use the converter for a property in a domain class:
```
    static searchable = {
        pdfAttachment converter: 'attachmentConverter'
    }
```