### PR TITLE
Fix startup failure when default port from environment variable

### DIFF
--- a/src/main/groovy/grails/plugins/elasticsearch/ClientNodeFactoryBean.groovy
+++ b/src/main/groovy/grails/plugins/elasticsearch/ClientNodeFactoryBean.groovy
@@ -51,7 +51,7 @@ class ClientNodeFactoryBean implements FactoryBean {
         } else {
             List<HttpHost> httpHostList = []
             elasticSearchContextHolder.config.client.hosts.each {
-                int port = it.port
+                int port = (it.port instanceof String)? Integer.valueOf(it.port) : it.port
                 httpHostList << new HttpHost("${it.host}", port)
             }
             HttpHost[] httpHosts = httpHostList


### PR DESCRIPTION
When setting the elastic search port number as environment variable and use it as default in application.yml, system will failure 

This commit fix the failure

Scenario:

* Set the environment variable as below: 

```
ES_HOST=elasticsearch
ES_USERNAME=elastic
ES_PASSWORD=elastic
ES_PORT=9200
ES_PORT=9200
```

* Set elastic search information in application.yml as below:
```
elasticSearch:
      cluster:
        name: es-docker-cluster
      client:
        mode: transport
        hosts:
          - 
            host: ${ES_HOST:localhost}
            port: ${ES_PORT:9200}
            username: ${ES_USERNAME:elastic}
            password: ${ES_PASSWORD:muyanEs2020}
```

Before apply this fix, system will fail to startup with error message as below
```
 Caused by: org.codehaus.groovy.runtime.typehandling.GroovyCastException: Cannot cast object '9200' with class 'java.lang.String' to class 'int'
```

After apply this fix, system can startup successfully and perform as expect.